### PR TITLE
[add] add the feature for setting the room to say message

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,19 @@ gem 'ruboty-chatwork'
 CHATWORK_API_TOKEN             - ChatWork API Token
 CHATWORK_ROOM                  - ChatWork Room ID
 CHATWORK_API_RATE              - ChatWork API Rate(Requests per Hour)
+CHATWORK_ROOM_FOR_SAYING       - ChatWork Room ID for Saying(Optional)
 ```
+
+## HOW TO SET THE ROOM TO SAY MESSAGE
+- Priority is high in numerical order (lower is ignored)
+    1. `room_id:12345678` statement at last in message by saying 
+        - ex. `ruboty Good Morning! room_id:12345678` 
+    2. `room_id` key in `reply` method
+        - ex. `message.reply("Hello!", room_id:12345678)`
+    3. ENV["CHATWORK_ROOM_FOR_SAYING"]
+    4. ENV["CHATWORK_ROOM"]
+- Note
+    - regexp of extracting `room_id` is poor ;)
 
 ## Contributing
 

--- a/lib/ruboty/adapters/chatwork.rb
+++ b/lib/ruboty/adapters/chatwork.rb
@@ -18,9 +18,13 @@ module Ruboty
 
       def say(message)
         pp message
-        req = Net::HTTP::Post.new(chatwork_messages_url.path, headers)
+
+        url_for_saying = chatwork_messages_url_for_saying(message)
+
+        req = Net::HTTP::Post.new(url_for_saying.path, headers)
         req.form_data = { 'body' => message[:body] }
-        https = Net::HTTP.new(chatwork_messages_url.host, chatwork_messages_url.port)
+
+        https = Net::HTTP.new(url_for_saying.host, url_for_saying.port)
         https.use_ssl = true
         https.start {|https| https.request(req) }
       end
@@ -45,6 +49,14 @@ module Ruboty
       end
       memoize :chatwork_messages_url
 
+      def chatwork_room_for_saying(message)
+        message[:original][:room_id] || message[:room_id] || ENV["CHATWORK_ROOM_FOR_SAYING"] || ENV["CHATWORK_ROOM"]
+      end
+
+      def chatwork_messages_url_for_saying(message)
+        URI.join(chatwork_url, "/v2/rooms/#{chatwork_room_for_saying(message)}/messages")
+      end
+
       def chatwork_api_rate
         ENV["CHATWORK_API_RATE"].to_i
       end
@@ -62,17 +74,38 @@ module Ruboty
           req = Net::HTTP::Get.new(chatwork_messages_url.path, headers)
           https = Net::HTTP.new(chatwork_messages_url.host, chatwork_messages_url.port)
           https.use_ssl = true
+
           res = https.start {|https| https.request(req) }
           pp res.body
+
           unless res.body.nil?
-            message = JSON.parse(res.body)
+            message       = JSON.parse(res.body)
+            original_body = message[0]['body']
+
+            body          = remove_room_id_statement(original_body)
+            from_name     = message[0]['account']['name']
+            room_id       = extract_room_id_statement(original_body)
+
             robot.receive(
-              body: message[0]['body'],
-              from_name: message[0]['account']['name']
+              body: body,
+              from_name: from_name,
+              room_id: room_id,
             )
           end
 
           sleep (60 * 60) / chatwork_api_rate
+        end
+      end
+
+      def extract_room_id_statement(original_body)
+        original_body[/(.*)( room_id:([0-9]+))\z/, 3]
+      end
+
+      def remove_room_id_statement(original_body)
+        if !(original_body[/(.*)( room_id:([0-9]+)\z)/, 1].nil?)
+          return original_body[/(.*)( room_id:([0-9]+)\z)/, 1].rstrip
+        else
+          original_body
         end
       end
     end


### PR DESCRIPTION
`ruboty-chatwork` is very useful, thanks.
I add the feature to this gem. the detail is shown `README.md`, but I describe it simply.

- can set the room to say message (reply)
    - by four ways, can set the room to say message
        - setting in saying message at last (`room_id:12345678`)
        - setting in `reply` method (message.reply("Hello!", `room_id: 12345678`))
        - ENV["CHATWORK_ROOM_FOR_SAYING"]
        - ENV["CHATWORK_ROOM"] (default)

I'm glad to meet this great gem :smile: 